### PR TITLE
FIX for has_cap() deprecation notice

### DIFF
--- a/smarty-for-wordpress.php
+++ b/smarty-for-wordpress.php
@@ -349,7 +349,7 @@ function smarty_load_demo($atts, $content=null, $code="") {
 function addSmartyManagementPage()
 {
     // Add a new submenu under Options:
-    add_options_page('Smarty for Wordpress', 'Smarty for Wordpress', 8, 'smartyforwordpress', 'displaySmartyManagementPage');
+    add_options_page('Smarty for Wordpress', 'Smarty for Wordpress', 'manage_options', 'smartyforwordpress', 'displaySmartyManagementPage');
 }
 
 // Display the admin page.


### PR DESCRIPTION
WP 5.1.1.
**Notice**:  has_cap was called with an argument that is **deprecated** since version 2.0.0! Usage of user levels is deprecated. Use capabilities instead. in **/wp-includes/functions.php** on line **4546**